### PR TITLE
SendSelection as a Slack ```preformatted``` message

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -204,8 +204,10 @@ class Slack
         }
 
         var selection = editor.selection;
-        var text = editor.document.getText(selection);
-        
+        var text = `\`\`\`
+        ${editor.document.getText(selection)}
+        \`\`\``;
+
         var data = {
             channel : '',
             token   : teamToken,


### PR DESCRIPTION
By wrapping the selection in triple back ticks, the message is sent as a preformatted chunk of text. This is a much cleaner way of sending code on Slack.
<img width="717" alt="screen shot 2016-01-15 at 12 40 16 am" src="https://cloud.githubusercontent.com/assets/6216460/12348944/96f2a7d4-bb20-11e5-9849-f537563a5d4c.png">
