### PR TITLE
Added option to post as authed user

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Go to User Settings (File > Preferences > User Settings) and add the following
 ```
     	"slack.teamToken": "<your team token>",
         "slack.username": "<your username>",
-        "slack.avatarUrl" : "<your avatar url>"
+        "slack.avatarUrl" : "<your avatar url>",
+        "slack.postAsUser" : true|false
 ```
 
 * ##### `"teamToken"` (required)
@@ -27,6 +28,10 @@ Go to User Settings (File > Preferences > User Settings) and add the following
 
 * ##### `"avatarUrl"` (optional)
     * Image for the avatar
+
+* ##### `"postAsUser"` (optional)
+    * **defaults to `false`**
+    * Set to true to post messages as the authed user, instead of as a bot''
 
 ### Features
 * Send messages to

--- a/package.json
+++ b/package.json
@@ -121,6 +121,11 @@
                     "type": "string",
                     "default": "http://i.imgur.com/O8dDZpb.png",
                     "description": "Slack avatar url"
+                },
+                "slack.postAsUser": {
+                    "type": "boolean",
+                    "default": "false",
+                    "description": "Post the message as the authed user, instead of as a bot"
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ var extension: vscode.ExtensionContext;
 var teamToken;
 var username;
 var avatarUrl;
+var postAsUser;
 
 var BASE_URL = 'https://slack.com/api/';
 var API_CHANNELS = 'channels.list';
@@ -225,7 +226,8 @@ class Slack
                     token   : teamToken,
                     username: username,
                     icon_url: avatarUrl,
-                    text    : text
+                    text    : text,
+                    as_user : postAsUser
                  };
 
                  if(text.startsWith("@") || text.startsWith("#")) {
@@ -256,7 +258,8 @@ class Slack
             token   : teamToken,
             username: username,
             icon_url: avatarUrl,
-            text    : text
+            text    : text,
+            as_user : postAsUser
         };
 
         this.GetChannelList(this.Send, API_POST_MESSAGE, data);
@@ -312,6 +315,7 @@ function reloadConfiguration() {
     const NEW_TEAM_TOKEN = teamToken = NEW_CONFIG.get('teamToken');
     username = NEW_CONFIG.get('username');
     avatarUrl = NEW_CONFIG.get('avatarUrl');
+    postAsUser = String(NEW_CONFIG.get('postAsUser'));
 
     if (NEW_TEAM_TOKEN) {
         disposables.push(


### PR DESCRIPTION
The Slack API (`chat.postMessage`) has an option to post as the authed user instead as a bot. This change enables setting this option from the extension settings